### PR TITLE
Restrict CI workflow runs to specific branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches-ignore:
-      - "automated/dependency_version_update"
-      - "automated/dependency_version_update_tmp"
+    branches:
+      - main
+      - 2201.[0-9]+.x
   repository_dispatch:
     types:
       check_connector_for_breaking_changes


### PR DESCRIPTION
This PR will restrict CI workflow runs only to main and 2201.x.x branches. Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/586